### PR TITLE
enh: minimize dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update -qq \
         ca-certificates \
         curl \
     && apt-get clean \
-    && rm -rf /tmp/* /var/cache/apt/* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     # Add new user.
     && useradd --no-user-group --create-home --shell /bin/bash neuro \
     && chmod a+s /opt \
@@ -34,7 +34,7 @@ RUN curl -sSLO https://repo.continuum.io/miniconda/Miniconda3-${miniconda_versio
 
 # Install pynets.
 COPY --chown=neuro:users . /opt/pynets
-RUN conda install -y \
+RUN conda install -yq \
       python=3.6 \
       matplotlib>=2.0.0 \
       numpy>=1.13.3 \
@@ -44,3 +44,12 @@ RUN conda install -y \
       traits \
     && conda clean -tipsy \
     && pip install --no-cache-dir -e /opt/pynets
+
+# Install skggm
+RUN conda install -yq \
+        cython \
+        libgfortran \
+        matplotlib \
+        openblas \
+    && conda clean -tipsy \
+    && pip install --no-cache-dir https://dl.dropbox.com/s/ghgl6lff2fmtldn/skggm-0.2.7-cp36-cp36m-linux_x86_64.whl

--- a/dockerfile
+++ b/dockerfile
@@ -1,39 +1,46 @@
-FROM andrewosh/binder-base
+FROM debian:stretch-slim
 
-USER root
+ARG DEBIAN_FRONTEND="noninteractive"
 
-# Add dependency
-RUN apt-get -qq update
-RUN conda update libgfortran --force
-RUN conda install libgcc --force
-RUN apt-get install -y libblas3gf libblas-doc libblas-dev liblapack3gf liblapack-doc liblapack-dev
-RUN apt-get install -y software-properties-common python-software-properties
-RUN apt-get install -y libxtst6 libgtk2.0-bin libxft2 lib32ncurses5 libXp6 libxpm-dev libxpm4 libxmu-dev
-#RUN apt-get install -y libbz2-dev libsqlite3-dev
+ENV LANG="C.UTF-8" \
+    LC_ALL="C.UTF-8"
 
-# Create python3 environment
-#RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz
-#RUN tar xvf Python-3.6.0.tgz
-#RUN cd Python-3.6.0 && ./configure --enable-optimizations --enable-loadable-sqlite-extensions && make -j8 && make altinstall
-#RUN wget https://bootstrap.pypa.io/get-pip.py && python3.6 get-pip.py
-#RUN rm -f Python-3.6.0.tgz
-RUN apt-get install -y python3-dev python3-pip
+RUN apt-get update -qq \
+    # Install system dependencies.
+    && apt-get install -y --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        curl \
+    && apt-get clean \
+    && rm -rf /tmp/* /var/cache/apt/* \
+    # Add new user.
+    && useradd --no-user-group --create-home --shell /bin/bash neuro \
+    && chmod a+s /opt \
+    && chmod 777 -R /opt
 
-RUN python3.4 -m pip install --upgrade pip
-RUN python3.4 -m pip install Cython>=0.24 nilearn>=0.2.4 numpy>=1.12.1 scikit-learn>=0.18.2 scipy>=0.19.1 pytest>=2.9.2 seaborn>=0.7.1 nose>=1.3.6 tabulate>=0.7.5 ipython
+USER neuro
+WORKDIR /home/neuro
 
-# Install requirements for Python 3
-RUN python3.4 -m pip install skggm --upgrade
-RUN python3.4 -m pip install pynets>=0.3.1 --upgrade
+# Install Miniconda.
+ARG miniconda_version="4.3.27"
+ENV PATH="/opt/conda/bin:$PATH"
+RUN curl -sSLO https://repo.continuum.io/miniconda/Miniconda3-${miniconda_version}-Linux-x86_64.sh \
+    && bash Miniconda3-${miniconda_version}-Linux-x86_64.sh -b -p /opt/conda \
+    && conda config --system --prepend channels conda-forge \
+    && conda config --system --set auto_update_conda false \
+    && conda config --system --set show_channel_urls true \
+    && conda clean -tipsy \
+    && rm -rf Miniconda3-${miniconda_version}-Linux-x86_64.sh
 
-RUN chmod 775 -R /usr/local/lib/python3.4
-RUN chown root:main -R /usr/local/lib/python3.4
-RUN chmod 777 /usr/local/bin/pynets_run.py
-
-USER main
-RUN python3.4 -m pip install pandas --upgrade --user
-
-#ENV PYTHONPATH /usr/local/lib/python3.4/dist-packages:$PYTHONPATH
-
-# Environment variable try to fix lapack issue
-ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libgfortran.so.3
+# Install pynets.
+COPY --chown=neuro:users . /opt/pynets
+RUN conda install -y \
+      python=3.6 \
+      matplotlib>=2.0.0 \
+      numpy>=1.13.3 \
+      scikit-learn>=0.19.1 \
+      scipy>=1.0.0 \
+      setuptools>=38.2.4 \
+      traits \
+    && conda clean -tipsy \
+    && pip install --no-cache-dir -e /opt/pynets


### PR DESCRIPTION
Hi @dpisner453 - this PR proposes changes that clean up and minimize the Dockerfile and resulting Docker image. I am proposing to use the Debian Stretch base Docker image as opposed to the `andrewosh/binder-base` because the Debian base is much smaller (~50 MB vs ~2GB) and because I didn't see how binder was a dependency of PyNets. Please let me know if you would like binder included in the Dockerfile. I also propose merging multiple `RUN` instructions to minimize layers, and I propose using conda's python as opposed to python installed via `apt-get`.